### PR TITLE
Show asset thumbnail when editing

### DIFF
--- a/public/app/js/controllers/assets.js
+++ b/public/app/js/controllers/assets.js
@@ -123,6 +123,7 @@ angular.module('piAssets.controllers',[])
                 if ($scope.fn.editMode) {
                     $scope.names = [];
                     $scope.asset.files.forEach(function (file) {
+                        var fileDetails = $scope.asset.filesDetails[file];
                         var name, ext;
                         if (file.lastIndexOf('.') == -1) {
                             name = file;
@@ -133,7 +134,9 @@ angular.module('piAssets.controllers',[])
                         }
                         $scope.names.push({
                             name: name,
-                            ext: ext
+                            ext: ext,
+                            file: file,
+                            fileDetails: fileDetails
                         })
                     });
                 } else {

--- a/public/app/partials/assets.html
+++ b/public/app/partials/assets.html
@@ -77,7 +77,9 @@
   <ul class="list-group">
     <li class="list-group-item" ng-repeat="name in names">
       <form class="row" name="editform">
-        <div class="form-group col-xs-10" ng-class="editform.$dirty?'':fieldStatus">
+        <div class="col-sm-2"><a ng-click="fn.showDetails(name.fileDetails.name)"><img class="media-object img-rounded" ng-if="name.fileDetails.thumbnail" ng-src="{{name.fileDetails.thumbnail}}"/>
+          <div class="letter-box media-object img-rounded" ng-if="!name.fileDetails.thumbnail"><span ng-if="name.fileDetails.type == &quot;audio&quot; || name.fileDetails.type == &quot;radio&quot;"><i class="fa fa-music"></i></span><span ng-if="name.fileDetails.type != &quot;audio&quot; &amp;&amp; name.fileDetails.type != &quot;radio&quot;">{{name.fileDetails.type.slice(0,1) || 'N'}}</span></div></a></div>
+        <div class="form-group col-xs-8" ng-class="editform.$dirty?'':fieldStatus">
           <div class="input-group col-xs-12">
             <input class="form-control" type="text" ng-model="name.name"/><span class="input-group-addon" ng-bind="name.ext" ng-hide="editform.$dirty"></span><span class="input-group-btn" ng-click="fn.rename($index)" ng-show="editform.$dirty"><a class="btn btn-success" type="button">SAVE</a></span>
           </div>

--- a/public/app/partials/assets.pug
+++ b/public/app/partials/assets.pug
@@ -121,7 +121,15 @@
     ul.list-group
         li.list-group-item(ng-repeat='name in names')
             form.row(name="editform")
-                .form-group.col-xs-10(ng-class="editform.$dirty?'':fieldStatus")
+                .col-sm-2
+                    a(ng-click='fn.showDetails(name.fileDetails.name)')
+                        img.media-object.img-rounded(ng-if='name.fileDetails.thumbnail',ng-src='{{name.fileDetails.thumbnail}}')
+                        .letter-box.media-object.img-rounded(ng-if='!name.fileDetails.thumbnail')
+                            span(ng-if='name.fileDetails.type == "audio" || name.fileDetails.type == "radio"')
+                                i.fa.fa-music
+                            span(ng-if='name.fileDetails.type != "audio" && name.fileDetails.type != "radio"')
+                                | {{name.fileDetails.type.slice(0,1) || 'N'}}
+                .form-group.col-xs-8(ng-class="editform.$dirty?'':fieldStatus")
                     .input-group.col-xs-12
                         input.form-control(type='text', ng-model='name.name')
                         span.input-group-addon(ng-bind="name.ext", ng-hide="editform.$dirty")


### PR DESCRIPTION
When I'm handing off the server management to someone else currently I have to explain if there is an issue with an image or they need to delete something they have to first find the image, note down the name and then search for it once in the edit view.

This changes the edit view for assets to display the same thumbnail to the side when in view mode. I think this is well worth the cost of making rows slightly bigger per entry for ease of use.