### PR TITLE
fix: correct imagemagick spelling in system-check warning

### DIFF
--- a/app/others/system-check.js
+++ b/app/others/system-check.js
@@ -55,7 +55,7 @@ module.exports = function(){
 			exec('convert -version',function(err,stdout,stderr){
                 if(err){
 					console.log('*********************************************************************');
-					console.log('* Please install imagemagik, otherwise thumbnails cannot be created *');
+					console.log('* Please install imagemagick, otherwise thumbnails cannot be created *');
 					console.log('*********************************************************************\n');
                     console.log(err)
                     errors++;


### PR DESCRIPTION
## Summary

- Fixes typo in `app/others/system-check.js`: `imagemagik` → `imagemagick`
- Adds missing newline at end of file

Fixes #231